### PR TITLE
add chromatic number test for Morgenstern Ramanujan graphs for even prime power q

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+GraphsColoring = "ed38bb8a-6120-4024-8d1e-8789784f251b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Multigraphs = "7ebac608-6c66-46e6-9856-b5f43e107bac"
 Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"

--- a/test/test_morgenstern.jl
+++ b/test/test_morgenstern.jl
@@ -2,6 +2,7 @@
     using Oscar
     using Graphs
     using Graphs: degree, vertices, nv, ne, is_bipartite, adjacency_matrix, diameter, is_connected, independent_set, has_edge, MaximalIndependentSet, greedy_color
+    using GraphsColoring: DSATUR, color, Greedy
     using LinearAlgebra
     using QuantumExpanders
     using SimpleGraphConverter
@@ -79,6 +80,12 @@
                 coloring = greedy_color(graph; sort_degree=false, reps=1000)
                 χ_greedy = coloring.num_colors
                 @test χ_greedy >= (q+1)/(2*sqrt(q))+1
+                colors_dsatur = color(graph; algorithm=DSATUR())
+                χ_dsatur = length(colors_dsatur.colors) 
+                @test χ_dsatur >= (q+1)/(2*sqrt(q))+1
+                colors_greedy = color(graph; algorithm=Greedy())
+                χ_greedy₂ = length(colors_greedy.colors) 
+                @test χ_greedy₂ >= (q+1)/(2*sqrt(q))+1
                 # Properties of generator set B
                 @test length(gens) == q+1
                 # All generators should have determinant 1.


### PR DESCRIPTION
Building on #16, this PR adds the chromatic number test which corresponds the property 5 of Theorem 5.13, page 61 of [Journal of Combinatorial Theory, Series B Volume 62, Issue 1](https://www.sciencedirect.com/journal/journal-of-combinatorial-theory-series-b/vol/62/issue/1), September 1994.

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them.

