### PR TITLE
add subgroup test: for symmetric generating sets A, B, left-right Cayley complex requires `〈A, B〉= G`

### DIFF
--- a/test/test_morgenstern.jl
+++ b/test/test_morgenstern.jl
@@ -32,12 +32,18 @@
                 @test all(((γ,δ),) -> γ^2 + γ*δ + ε*δ^2 == one(Fq), sols)
                 A_first = alternative_morgenstern_generators(gens, FirstOnly())
                 @test length(A_first) == 2*q
+                gensₐₗₗ = vcat(gens, A_first)
+                H, _ = sub(SL₂, gensₐₗₗ)
+                @test H == SL₂
                 A_pairs = alternative_morgenstern_generators(gens, AllPairs())
                 @test length(A_pairs) == q*(q+1)
                 @test is_nonconjugate(SL₂, A_first, gens)
                 @test is_nonconjugate(SL₂, A_pairs, gens)
                 @test is_symmetric_gen(A_pairs)
                 @test is_symmetric_gen(A_first)
+                gensₐₗₗ = vcat(gens, A_pairs)
+                H, _ = sub(SL₂, gensₐₗₗ)
+                @test H == SL₂
             end
         end
     end


### PR DESCRIPTION
Building on #16,  this PR adds the subgroup test which states for symmetric generating sets A, B, left right  Cayley complex requires `〈A, B〉= G`

- [x] The code is properly formatted and commented.
- [x] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [x] All of the automated tests on github pass.
- [x] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. 