### PR TITLE
Simplify downgrade CI on Julia 1.12

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -8,37 +8,45 @@ on:
     branches: [master, main]
     paths-ignore:
       - 'docs/**'
-env:
-  PYTHON: ~
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: ['1.12']
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: ${{ matrix.version }}
-      - name: Disable workspace directives for downgrade run
+          version: '1.12'
+      - uses: julia-actions/cache@v3
+        with:
+          delete-old-caches: false
+      - name: Prepare general test workspace
         run: |
           julia --color=yes -e '
             using TOML
+            write_toml(path, data) = open(io -> TOML.print(io, data), path, "w")
+
             project = TOML.parsefile("Project.toml")
-            if haskey(project, "workspace")
-              delete!(project, "workspace")
-              open("Project.toml", "w") do io
-                TOML.print(io, project)
-              end
-            end
+            project["workspace"]["projects"] = ["test"]
+            write_toml("Project.toml", project)
+
+            test_project = TOML.parsefile("test/Project.toml")
+            get!(test_project, "sources", Dict{String, Any}())["QuantumExpanders"] = Dict("path" => "..")
+            write_toml("test/Project.toml", test_project)
           '
-      - uses: julia-actions/julia-downgrade-compat@v2
+      - uses: julia-actions/julia-downgrade-compat@v2.7.0
         with:
-          skip: Pkg,TOML,InteractiveUtils,Random,LinearAlgebra,SparseArrays
+          skip: 'LinearAlgebra,Random,SparseArrays'
+          projects: '.,test'
           mode: 'forcedeps'
-          julia_version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v3
+          julia_version: '1.12'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.12'
+          version: 'min'
       - uses: julia-actions/cache@v3
         with:
           delete-old-caches: false
@@ -42,7 +42,7 @@ jobs:
           projects: '.,test'
           skip: LinearAlgebra,Random,SparseArrays
           mode: 'forcedeps'
-          julia_version: '1.12'
+          julia_version: 'min'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -39,8 +39,8 @@ jobs:
           '
       - uses: julia-actions/julia-downgrade-compat@v2.7.0
         with:
-          skip: LinearAlgebra,Random,SparseArrays
           projects: '.,test'
+          skip: LinearAlgebra,Random,SparseArrays
           mode: 'forcedeps'
           julia_version: '1.12'
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -27,23 +27,19 @@ jobs:
       - uses: julia-actions/cache@v3
         with:
           delete-old-caches: false
-      - name: Prepare general test workspace
+      - name: Limit workspace to the test project
         run: |
           julia --color=yes -e '
             using TOML
-            write_toml(path, data) = open(io -> TOML.print(io, data), path, "w")
-
             project = TOML.parsefile("Project.toml")
             project["workspace"]["projects"] = ["test"]
-            write_toml("Project.toml", project)
-
-            test_project = TOML.parsefile("test/Project.toml")
-            get!(test_project, "sources", Dict{String, Any}())["QuantumExpanders"] = Dict("path" => "..")
-            write_toml("test/Project.toml", test_project)
+            open("Project.toml", "w") do io
+              TOML.print(io, project)
+            end
           '
       - uses: julia-actions/julia-downgrade-compat@v2.7.0
         with:
-          skip: 'LinearAlgebra,Random,SparseArrays'
+          skip: LinearAlgebra,Random,SparseArrays
           projects: '.,test'
           mode: 'forcedeps'
           julia_version: '1.12'

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -23,26 +23,15 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: 'min'
+          version: '1.12'
       - uses: julia-actions/cache@v3
         with:
           delete-old-caches: false
-      - name: Limit workspace to the test project
-        run: |
-          julia --color=yes -e '
-            using TOML
-            project = TOML.parsefile("Project.toml")
-            project["workspace"]["projects"] = ["test"]
-            open("Project.toml", "w") do io
-              TOML.print(io, project)
-            end
-          '
       - uses: julia-actions/julia-downgrade-compat@v2.7.0
         with:
           projects: '.,test'
           skip: LinearAlgebra,Random,SparseArrays
           mode: 'forcedeps'
-          julia_version: 'min'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -26,6 +26,9 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
+[sources]
+QuantumExpanders = {path = ".."}
+
 [compat]
 # Pin native HiGHS before ERGO-Code/HiGHS#3141; remove after a fixed release.
 HiGHS = "=1.19.3"


### PR DESCRIPTION
## Summary
- run lower-bound resolution and testing on Julia 1.12
- resolve root and split test environments together, then build and test the locked graph
- disable both `Pkg.test` re-resolution paths
- remove pre-1.12 setup, manifest-repair, workspace-rewrite, and direct-test workarounds
- retain strict `forcedeps` verification and only the required stdlib exclusions

No compat bounds are added to `test/Project.toml`.

## Validation
- `actionlint`
- all Project TOML files parsed with Julia 1.12
- aggregate workflow-contract and stdlib-skip checks
- targeted locked-manifest runs on representative and exceptional repositories
- two independent cross-repository reviews

Existing package lower-bound failures are intentionally left visible for separate follow-up.

## Repository-specific note
The test project keeps only the parent `[sources]` mapping required to resolve this unregistered checked-out package; it has no added compat bounds.