### PR TITLE
Require TestItemRunner 1.1.5 for filtered tests

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+env:
+  QUANTUMSAVORY_DOWNGRADE_TEST: "true"
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -33,3 +33,4 @@ QuantumExpanders = {path = ".."}
 # Pin native HiGHS before ERGO-Code/HiGHS#3141; remove after a fixed release.
 HiGHS = "=1.19.3"
 StableRNGs = "1"
+TestItemRunner = "1.1.5"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -32,5 +32,6 @@ QuantumExpanders = {path = ".."}
 [compat]
 # Pin native HiGHS before ERGO-Code/HiGHS#3141; remove after a fixed release.
 HiGHS = "=1.19.3"
+NautyGraphs = ">= 0.3.1"
 StableRNGs = "1"
 TestItemRunner = "1.1.5"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -33,5 +33,6 @@ QuantumExpanders = {path = ".."}
 # Pin native HiGHS before ERGO-Code/HiGHS#3141; remove after a fixed release.
 HiGHS = "=1.19.3"
 NautyGraphs = ">= 0.3.1"
+SimpleGraphAlgorithms = ">= 0.4.20"
 StableRNGs = "1"
 TestItemRunner = "1.1.5"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ testfilter = ti -> begin
         push!(exclude, :jet)
     end
 
-    if !(VERSION >= v"1.10")
+    if !(VERSION >= v"1.10") || get(ENV, "QUANTUMSAVORY_DOWNGRADE_TEST", "") == "true"
         push!(exclude, :doctests)
         push!(exclude, :aqua)
     end


### PR DESCRIPTION
## Summary

- require TestItemRunner 1.1.5 in the test environment
- prevent downgrade CI from selecting the obsolete filtered-runner API
- require NautyGraphs 0.3.1 or later, the first release compatible with the current nauty_jll API
- require SimpleGraphAlgorithms 0.4.20 or later in the test environment
- set the shared QUANTUMSAVORY_DOWNGRADE_TEST flag
- exclude tagged Aqua and doctest items only from downgrade CI
- keep JET on its existing dedicated path and leave action inputs unchanged

## Validation

- SimpleGraphAlgorithms 0.4.19 reproduces the Julia 1.12 test failure because chrome_poly.jl dispatches on the removed SimpleDigraph name
- SimpleGraphAlgorithms 0.4.20 is the first fixed release; commit fa422f9 changes the dispatch to the DG alias exported by SimpleGraphs 0.8
- exact julia-downgrade-compat v2.7.0 forced resolution previously passed with TestItemRunner 1.1.5 and NautyGraphs 0.3.1
- NautyGraphs 0.3.0 reproduces the libnautyL0 precompile failure; 0.3.1 loads and its graph operations pass with both the minimum and current compatible nauty_jll
- changed TOML parses
- git diff --check
- hosted CI provides the locked full integration test; local Julia was not rerun because the shared host is PID-exhausted